### PR TITLE
simplify rental logic for ERC721SingleRentalAgreement

### DIFF
--- a/contracts/token/ERC721/ERC721SingleRentalAgreement.sol
+++ b/contracts/token/ERC721/ERC721SingleRentalAgreement.sol
@@ -8,6 +8,7 @@ import "../../utils/introspection/ERC165.sol";
 /// Define a simple rental agreement following the principles:
 ///   - The rent is valid for a rental period. The rental period has to be over to finish the rental.
 ///   - The rent has an exipration date: after this date it cannot be started.
+///   - Anybody (except the owner) can pay & start the rent and becomes the renter.
 ///   - The rent can be started only once.
 ///   - The rent have to be paid by the renter to the original owner.
 ///   - The contract exposes a function redeemFunds for the original owner to redeem the funds.

--- a/test/token/ERC721/ERC721SingleRentalAgreement.test.js
+++ b/test/token/ERC721/ERC721SingleRentalAgreement.test.js
@@ -127,5 +127,20 @@ contract('ERC721SingleRentalAgreement', function (accounts) {
       const status = await this.erc721SingleRentalAgreement.rentalStatus();
       expect(status.toNumber()).to.equal(RENT_STATUS.FINISHED);
     });
+    it('Redeem funds', async function () {
+      await startRent(this.erc721SingleRentalAgreement, this.renter, this.rentalFees, this.erc721, this.tokenId);
+      await time.increase(1809600); // Increase Ganache time by 2 weeks.
+      await this.erc721.stopRentalAgreement(this.tokenId, { from: this.owner });
+
+      // Only owner can redeem the funds.
+      await expectRevert(this.erc721SingleRentalAgreement.redeemFunds(this.rentalFees, { from: this.renter }),
+        'ERC721SingleRentalAgreement: only owner can redeem funds');
+      await expectRevert(this.erc721SingleRentalAgreement.redeemFunds(this.rentalFees, { from: this.otherAccount }),
+        'ERC721SingleRentalAgreement: only owner can redeem funds');
+      await expectRevert(this.erc721SingleRentalAgreement.redeemFunds(this.rentalFees + 1, { from: this.owner }),
+        'ERC721SingleRentalAgreement: not enough funds to redeem');
+
+      await this.erc721SingleRentalAgreement.redeemFunds(this.rentalFees, { from: this.owner });
+    });
   });
 });

--- a/test/token/ERC721/ERC721SingleRentalAgreement.test.js
+++ b/test/token/ERC721/ERC721SingleRentalAgreement.test.js
@@ -1,5 +1,5 @@
 const { BN, time, expectRevert } = require('@openzeppelin/test-helpers');
-const { assert, expect } = require('chai');
+const { expect } = require('chai');
 
 const ERC721Mock = artifacts.require('ERC721Mock');
 const ERC721SingleRentalAgreement = artifacts.require('ERC721SingleRentalAgreement');
@@ -14,6 +14,7 @@ contract('ERC721SingleRentalAgreement', function (accounts) {
   beforeEach(async function () {
     // Rental period.
     this.duration = new BN('604800'); // One week.
+    /// Expiration period.
     this.exp = new BN('1814400'); // Three weeks.
     this.latestTime = await time.latest();
     this.expirationDate = this.latestTime.add(this.exp);
@@ -22,21 +23,19 @@ contract('ERC721SingleRentalAgreement', function (accounts) {
     this.rentalFees = new BN('20000');
 
     // Accounts.
-    [this.owner, this.renter] = accounts;
+    [this.owner, this.renter, this.otherAccount] = accounts;
 
     // Erc721 contracts
     this.name = 'Non Fungible Token';
     this.symbol = 'NFT';
     this.erc721 = await ERC721Mock.new(this.name, this.symbol);
-    this.erc721Address = this.erc721.address;
     this.tokenId = new BN('12345');
     this.erc721.mint(this.owner, this.tokenId);
 
     // Initialize a new contract.
     this.erc721SingleRentalAgreement = await ERC721SingleRentalAgreement.new(
-      this.owner,
-      this.renter,
-      this.erc721Address,
+      this.erc721.address,
+      this.tokenId,
       this.duration,
       this.expirationDate,
       this.rentalFees,
@@ -46,7 +45,7 @@ contract('ERC721SingleRentalAgreement', function (accounts) {
     await this.erc721.setRentalAgreement(this.erc721SingleRentalAgreement.address, this.tokenId, { from: this.owner });
   });
 
-  context('Start Rent', async function () {
+  context('Initial state', async function () {
     it('contract initial is pending', async function () {
       const status = await this.erc721SingleRentalAgreement.rentalStatus();
       expect(status.toNumber()).to.equal(RENT_STATUS.PENDING);
@@ -59,88 +58,74 @@ contract('ERC721SingleRentalAgreement', function (accounts) {
       );
     });
 
-    it('Cannot start rent if rent not paid', async function () {
-      await expectRevert(
-        this.erc721.acceptRentalAgreement(this.renter, this.tokenId, { from: this.renter }),
-        'ERC721SingleRentalAgreement: rent has to be paid first',
-      );
+    it('Enable to change agreement when status is pending', async function () {
+      await this.erc721SingleRentalAgreement.afterRentalAgreementReplaced(this.tokenId, { from: this.erc721.address });
     });
+  });
 
+  context('start rent', async function () {
     it('Wrong rent fees', async function () {
       // Pay rent with wrong fee amount.
       await expectRevert(
-        this.erc721SingleRentalAgreement.payRent({ from: this.renter, value: this.rentalFees + 1 }),
+        this.erc721SingleRentalAgreement.payAndStartRent({ from: this.renter, value: this.rentalFees + 1 }),
         'ERC721SingleRentalAgreement: wrong rental fees amount',
-      );
-    });
-
-    it('Enable to start rent after rent is paid', async function () {
-      // Pay rent.
-      await this.erc721SingleRentalAgreement.payRent({ from: this.renter, value: this.rentalFees });
-      const rentPaid = await this.erc721SingleRentalAgreement.rentPaid();
-      assert.equal(rentPaid, true);
-
-      // Assert rent is active.
-      await this.erc721.acceptRentalAgreement(this.renter, this.tokenId, { from: this.renter });
-      const status = await this.erc721SingleRentalAgreement.rentalStatus();
-      expect(status.toString()).to.equal(RENT_STATUS.ACTIVE.toString());
-    });
-
-    it('Enable to change agreement when pending and not paid', async function () {
-      await this.erc721SingleRentalAgreement.afterRentalAgreementReplaced(this.tokenId, { from: this.erc721Address });
-    });
-
-    it('Cannot change agreement after the rent has been paid', async function () {
-      // Pay rent.
-      await this.erc721SingleRentalAgreement.payRent({ from: this.renter, value: this.rentalFees });
-      await expectRevert(
-        this.erc721SingleRentalAgreement.afterRentalAgreementReplaced(this.tokenId, { from: this.erc721Address }),
-        'ERC721SingleRentalAgreement: rent already paid',
       );
     });
 
     it('Cannot start rent after expiration date', async function () {
       await time.increase(1814400); // Increase ganache time by 3 weeks.
 
-      // Pay rent.
+      // Attempt to pay and start rent.
       await expectRevert(
-        this.erc721SingleRentalAgreement.payRent({ from: this.renter, value: this.rentalFees }),
+        this.erc721SingleRentalAgreement.payAndStartRent({ from: this.renter, value: this.rentalFees }),
         'ERC721SingleRentalAgreement: rental agreement expired',
+      );
+    });
+
+    it('Start rent', async function () {
+      // Pay rent.
+      await this.erc721SingleRentalAgreement.payAndStartRent({ from: this.renter, value: this.rentalFees });
+      const status = await this.erc721SingleRentalAgreement.rentalStatus();
+      expect(status.toNumber()).to.equal(RENT_STATUS.ACTIVE);
+    });
+
+    it('Cannot change agreement after the rent has started', async function () {
+      // Pay rent.
+      await this.erc721SingleRentalAgreement.payAndStartRent({ from: this.renter, value: this.rentalFees });
+      await expectRevert(
+        this.erc721SingleRentalAgreement.afterRentalAgreementReplaced(this.tokenId, { from: this.erc721.address }),
+        'ERC721SingleRentalAgreement: rental agreement has to be pending to be updated',
       );
     });
   });
 
   const startRent = async function (agreement, renter, fees, erc721, tokenId) {
-    // Pay rent.
-    await agreement.payRent({ from: renter, value: fees });
-    // Start rent.
-    await erc721.acceptRentalAgreement(renter, tokenId, { from: renter });
+    // Pay and start rent.
+    await agreement.payAndStartRent({ from: renter, value: fees });
   };
 
   context('Finish rent', async function () {
-    it('Owner cannot finish rent before the rental period is over', async function () {
+    it('Owner and renter cannot finish rent before the rental period is over', async function () {
       await startRent(this.erc721SingleRentalAgreement, this.renter, this.rentalFees, this.erc721, this.tokenId);
       await expectRevert(
         this.erc721.stopRentalAgreement(this.tokenId, { from: this.owner }),
         'ERC721SingleRentalAgreement: rental period not finished yet',
       );
+      await expectRevert(
+        this.erc721.stopRentalAgreement(this.tokenId, { from: this.renter }),
+        'ERC721SingleRentalAgreement: rental period not finished yet',
+      );
     });
-
-    it('Owner is able to finish rent after the rental period is over', async function () {
+    it('Only owner, approver, operator or renter can finish rent', async function () {
       await startRent(this.erc721SingleRentalAgreement, this.renter, this.rentalFees, this.erc721, this.tokenId);
       await time.increase(1809600); // Increase Ganache time by 2 weeks.
+      await expectRevert(
+        this.erc721.stopRentalAgreement(this.tokenId, { from: this.otherAccount }),
+        'ERC721SingleRentalAgreement: only owner, approver or renter can finish rent',
+      );
       await this.erc721.stopRentalAgreement(this.tokenId, { from: this.owner });
-    });
-
-    it('Renter is able to finish rent before the rental period is over', async function () {
-      await startRent(this.erc721SingleRentalAgreement, this.renter, this.rentalFees, this.erc721, this.tokenId);
-      await time.increase(302400); // Increase Ganache time by 3.5 days.
-      await this.erc721.stopRentalAgreement(this.tokenId, { from: this.renter });
-      const renterBalance = await this.erc721SingleRentalAgreement.balances(this.renter);
-      const ownerBalance = await this.erc721SingleRentalAgreement.balances(this.owner);
-      const expectedBalance = new BN(10000);
-      assert.equal(renterBalance.toNumber(), expectedBalance.toNumber());
-      assert.equal(ownerBalance.toNumber(), expectedBalance.toNumber());
+      const status = await this.erc721SingleRentalAgreement.rentalStatus();
+      expect(status.toNumber()).to.equal(RENT_STATUS.FINISHED);
     });
   });
 });


### PR DESCRIPTION
Simplify the logic:
- No early termination is possible: the rental period has to be over to finish the rent.
- Paying the rent will automatically start the rental period.
- Anybody can pay and start the rent: The contract doesn't specify the renter during construction anymore.

(simple) optimization:
Changed time variables to uint40.
